### PR TITLE
Allow both prefix and path via prefix_with_path

### DIFF
--- a/bin/i15r
+++ b/bin/i15r
@@ -17,6 +17,10 @@ def parse_options(args)
             "Apply PREFIX to generated I18n messages instead of deriving it from the path") do |prefix|
       options[:prefix] = prefix
     end
+    opts.on("--prefix_with_path PREFIX",
+            "Apply PREFIX to generated I18n messages in front of the path") do |prefix|
+      options[:prefix_with_path] = prefix
+    end
     opts.on("-n", "--dry-run", "Do not write the files, just show the diff") do
       options[:dry_run] = true
     end

--- a/spec/i15r_spec.rb
+++ b/spec/i15r_spec.rb
@@ -92,6 +92,17 @@ describe I15R do
         subject.internationalize_file(path)
       end
     end
+
+    describe "when there is an explicit prefix with path" do
+      let(:path) { "app/views/users/_badge.html.erb" }
+
+      subject { I15R.new(reader, writer, I15R::NullPrinter.new, :prefix_with_path => "nice") }
+
+      specify do
+        writer.should_receive(:write).with(path, %Q{<label for="user-name"><%= I18n.t("nice.users.badge.name", :default => "Name") %></label>\n})
+        subject.internationalize_file(path)
+      end
+    end
   end
 
   describe "the add_default option" do


### PR DESCRIPTION
We want a prefix but want to include the path too, so the --prefix_with_path options gives that.
