### PR TITLE
Allow override of I18n.t method

### DIFF
--- a/bin/i15r
+++ b/bin/i15r
@@ -27,6 +27,9 @@ def parse_options(args)
     opts.on("--no-default", "Do not insert the replaced string as the :default in the I18n string") do
       options[:add_default] = false
     end
+    opts.on("--override_i18n_method METHOD", "Replace I18n.t with METHOD") do |m|
+      options[:override_i18n_method] = m
+    end
 
     opts.on_tail("-h", "--help", "Show this message") do
       puts opts

--- a/lib/i15r.rb
+++ b/lib/i15r.rb
@@ -23,6 +23,10 @@ class I15R
     def add_default
       @options.fetch(:add_default, true)
     end
+
+    def override_i18n_method
+      @options.fetch(:override_i18n_method, nil)
+    end
   end
 
   attr_reader :config
@@ -75,7 +79,8 @@ class I15R
   end
 
   def sub_plain_strings(text, prefix, file_type)
-    pm = I15R::PatternMatcher.new(prefix, file_type, :add_default => config.add_default)
+    pm = I15R::PatternMatcher.new(prefix, file_type, :add_default => config.add_default,
+                                  :override_i18n_method => config.override_i18n_method)
     transformed_text = pm.run(text) do |old_line, new_line|
       @printer.print_diff(old_line, new_line)
     end

--- a/lib/i15r/pattern_matcher.rb
+++ b/lib/i15r/pattern_matcher.rb
@@ -29,7 +29,7 @@ class I15R
       @prefix = prefix
       @file_type = file_type
       transformer_class = self.class.const_get("#{file_type.to_s.capitalize}Transformer")
-      @transformer = transformer_class.new(options[:add_default])
+      @transformer = transformer_class.new(options[:add_default], options[:override_i18n_method] || 'I18n.t')
     end
 
     def translation_key(text)
@@ -61,8 +61,9 @@ class I15R
     end
 
     class Transformer
-      def initialize(add_default)
+      def initialize(add_default, i18n_method)
         @add_default = add_default
+        @i18n_method = i18n_method
       end
 
       private
@@ -74,9 +75,9 @@ class I15R
             unless original[0] == "'" or original[0] == '"'
               original = %("#{original}")
             end
-            %(I18n.t("#{key}", :default => #{original}))
+            %(#{@i18n_method}("#{key}", :default => #{original}))
           else
-            %(I18n.t("#{key}"))
+            %(#{@i18n_method}("#{key}"))
           end
         end
     end

--- a/spec/pattern_matcher_spec.rb
+++ b/spec/pattern_matcher_spec.rb
@@ -52,6 +52,13 @@ describe I15R::PatternMatcher do
                                  .to(%(    <%= f.label I18n.t("users.new.name") %><br />)) }
       end
 
+      describe "when the I18n function is overriden" do
+        let(:pattern_matcher) { I15R::PatternMatcher.new("users.new", :erb, :override_i18n_method => 't') }
+
+        it { should internationalize('<h1>New flight</h1>')
+                                 .to('<h1><%= t("users.new.new_flight") %></h1>') }
+      end
+
       describe "when a line is already international" do
         it { should internationalize(%(  <%= f.label I18n.t("users.new.name") %>)).to_the_same }
         it { should internationalize(%(  <%= f.label t("users.new.name") %>)).to_the_same }
@@ -182,6 +189,12 @@ describe I15R::PatternMatcher do
       let(:pattern_matcher) { I15R::PatternMatcher.new("users.show", :haml, :add_default => false ) }
       it { should internationalize(%(  %h3 Top Scorers))
                                .to(%(  %h3= I18n.t("users.show.top_scorers"))) }
+    end
+
+    describe "when the I18n function is overriden" do
+      let(:pattern_matcher) { I15R::PatternMatcher.new("users.show", :haml, :override_i18n_method => 't', :add_default => true) }
+      it { should internationalize(%(  %h3 Top Scorers))
+                               .to(%(  %h3= t("users.show.top_scorers", :default => "Top Scorers"))) }
     end
 
     describe "when already evaluated" do


### PR DESCRIPTION
This allows you to use `t` or whatever else you want in place of `I18n.t`
