### PR TITLE
Internationalize title and alt attributes

### DIFF
--- a/lib/i15r/pattern_matcher.rb
+++ b/lib/i15r/pattern_matcher.rb
@@ -10,6 +10,7 @@ class I15R
         /<%=.*submit(_tag)?\s+(?<submit-text>(['"].+?['"]|:[[:alnum:]_]+))/,
         />(?<tag-content>(?!&.*;)[[:space:][:alnum:][:punct:]]+?)<\//,
         /\s+title=['"](?<link-title>.+?)['"]/,
+        /\s+alt=['"](?<img-alt>.+?)['"]/,
         /^\s*(?<pre-tag-text>[[:alnum:]]+[[:alnum:][:space:][:punct:]]*?)</,
         /^(?!^var .*)(?!.*(%>|{|})$)(?!.*(:|=).*(;|,)$)(?!.*return .*;$)(?!.*=)(?!^(if |unless ).*(\=|\&|\|))(?!^(if |unless )\S+$)(?!^end$)(?!.*do.*\|$)\s*(?<no-markup-content>[[:alnum:]]+[[:alnum:][:space:][:punct:]]*)/
       ],

--- a/lib/i15r/pattern_matcher.rb
+++ b/lib/i15r/pattern_matcher.rb
@@ -9,7 +9,7 @@ class I15R
         /<%=.*label(_tag)?.*?,\s*(?<label-title>(['"].+?['"]|:[[:alnum:]_]+))/,
         /<%=.*submit(_tag)?\s+(?<submit-text>(['"].+?['"]|:[[:alnum:]_]+))/,
         />(?<tag-content>(?!&.*;)[[:space:][:alnum:][:punct:]]+?)<\//,
-        /<a\s+title=['"](?<link-title>.+?)['"]/,
+        /\s+title=['"](?<link-title>.+?)['"]/,
         /^\s*(?<pre-tag-text>[[:alnum:]]+[[:alnum:][:space:][:punct:]]*?)</,
         /^(?!^var .*)(?!.*(%>|{|})$)(?!.*(:|=).*(;|,)$)(?!.*return .*;$)(?!.*=)(?!^(if |unless ).*(\=|\&|\|))(?!^(if |unless )\S+$)(?!^end$)(?!.*do.*\|$)\s*(?<no-markup-content>[[:alnum:]]+[[:alnum:][:space:][:punct:]]*)/
       ],

--- a/spec/pattern_matcher_spec.rb
+++ b/spec/pattern_matcher_spec.rb
@@ -130,9 +130,6 @@ describe I15R::PatternMatcher do
     describe "in tag attributes" do
       it { should internationalize(%(<a title="site root" href="/"><img src="site_logo.png" /></a>))
                                .to(%(<a title="<%= I18n.t("users.new.site_root") %>" href="/"><img src="site_logo.png" /></a>)) }
-
-      it { should internationalize(%(<a title="site root" href="/"><img src="site_logo.png" /></a>))
-                               .to(%(<a title="<%= I18n.t("users.new.site_root") %>" href="/"><img src="site_logo.png" /></a>)) }
     end
 
     describe "Rails helper methods" do

--- a/spec/pattern_matcher_spec.rb
+++ b/spec/pattern_matcher_spec.rb
@@ -133,6 +133,9 @@ describe I15R::PatternMatcher do
       
       it { should internationalize(%(<button title="action button"><img src="button.png" /></button>))
                                .to(%(<button title="<%= I18n.t("users.new.action_button") %>"><img src="button.png" /></button>)) }
+      
+      it { should internationalize(%(<img src="image.jpg" alt="Beautiful image" />))
+                               .to(%(<img src="image.jpg" alt="<%= I18n.t("users.new.beautiful_image") %>" />)) }
     end
 
     describe "Rails helper methods" do

--- a/spec/pattern_matcher_spec.rb
+++ b/spec/pattern_matcher_spec.rb
@@ -130,6 +130,9 @@ describe I15R::PatternMatcher do
     describe "in tag attributes" do
       it { should internationalize(%(<a title="site root" href="/"><img src="site_logo.png" /></a>))
                                .to(%(<a title="<%= I18n.t("users.new.site_root") %>" href="/"><img src="site_logo.png" /></a>)) }
+      
+      it { should internationalize(%(<button title="action button"><img src="button.png" /></button>))
+                               .to(%(<button title="<%= I18n.t("users.new.action_button") %>"><img src="button.png" /></button>)) }
     end
 
     describe "Rails helper methods" do


### PR DESCRIPTION
Before this, `title` attributes were only internationalized if inside anchor tags. Now `title` attributes are translated regardless of where the tags they appear in.

This branch also internationalizes `alt` attributes. `alt` attributes are allowed in `img`, `area` and `applet` tags, so I didn't include the opening tag to the regex.

Tests are provided and they pass.

Note: I removed a duplicated test for the title attribute because it didn't seem to add anything (it was just duplicated). If I missed something and that shouldn't have been done, I am sorry.

Hope this helps.