### PR TITLE
Add an option to create a Locale File.

### DIFF
--- a/bin/i15r
+++ b/bin/i15r
@@ -30,6 +30,9 @@ def parse_options(args)
     opts.on("--override_i18n_method METHOD", "Replace I18n.t with METHOD") do |m|
       options[:override_i18n_method] = m
     end
+    opts.on("--create-locale-file FILE_NAME", "Create a locale file with the given name.") do |m|
+      options[:create_locale_file] = m
+    end
 
     opts.on_tail("-h", "--help", "Show this message") do
       puts opts

--- a/lib/i15r/locale_creator.rb
+++ b/lib/i15r/locale_creator.rb
@@ -1,0 +1,67 @@
+require 'yaml'
+
+class I15R
+  class LocaleCreator
+    def initialize(file_name = nil)
+      @file_name = file_name
+      @structure = LocaleStructure.new
+    end
+
+    def add(path, value)
+      if @file_name
+        @structure.add(path, value)
+      end
+    end
+
+    def save_file
+      if @file_name
+        yaml = @structure.to_yaml(:en)
+        File.write("#{@file_name}.yml", yaml)
+      end
+    end
+
+    class LocaleStructure
+      attr_reader :structure
+
+      def initialize
+        @structure = {}
+      end
+
+      def add(path, value)
+        keys = path.dup.split('.')
+
+        h = nested_hash_for(keys, value)
+
+        @structure = deep_merge(self.structure, h)
+      end
+
+      def to_yaml(language)
+        { language.to_s => @structure }.to_yaml
+      end
+
+      private
+
+      def nested_hash_for(keys, value)
+        if keys.size == 1
+          { keys.delete_at(0) => value }
+        else
+          { keys.delete_at(0) => nested_hash_for(keys, value) }
+        end
+      end
+
+      def deep_merge(hash, other_hash)
+        other_hash.each_pair do |current_key, other_value|
+          this_value = hash[current_key]
+
+          hash[current_key] = if this_value.is_a?(Hash) && other_value.is_a?(Hash)
+            deep_merge(this_value, other_value)
+          else
+            other_value
+          end
+        end
+
+        hash
+      end
+    end
+  end
+end

--- a/spec/i15r_spec.rb
+++ b/spec/i15r_spec.rb
@@ -118,7 +118,7 @@ describe I15R do
       end
       specify do
         I15R::PatternMatcher.should_receive(:new)
-                            .with(anything, anything, hash_including(:add_default => true))
+                            .with(anything, anything, anything, hash_including(:add_default => true))
                             .and_return(patter_matcher)
         subject.internationalize_file(path)
       end
@@ -130,7 +130,7 @@ describe I15R do
       end
       specify do
         I15R::PatternMatcher.should_receive(:new)
-                            .with(anything, anything, hash_including(:add_default => false))
+                            .with(anything, anything, anything, hash_including(:add_default => false))
                             .and_return(patter_matcher)
         subject.internationalize_file(path)
       end


### PR DESCRIPTION
Now it'll be possible to create an locale yaml file from the fixed texts with the created i18n keys.

To create the file it's just use the  option `--create-locale-file <file_name>` and a `<file_name>.yml` will be created with all the keys created, using the "default" texts as values.

For now, the file is created as `en`. Maybe would be nice to add other option to specify the language.