### PR TITLE
force utf8 as default encoding

### DIFF
--- a/lib/i15r/file_reader.rb
+++ b/lib/i15r/file_reader.rb
@@ -1,7 +1,7 @@
 class I15R
   class FileReader
     def read(file)
-      File.read(File.expand_path(file))
+      File.read(File.expand_path(file)).force_encoding("UTF-8")
     end
   end
 end


### PR DESCRIPTION
The i15r bin file is in some cases us-ascii encoding and so the whole project can't be validated if special chars like äöü or others are present. If we enforce utf-8 as default this isn't a problem
